### PR TITLE
The use of getBlockLocation directly from event

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -372,8 +372,8 @@ world.events.itemUse.subscribe(async itemUse => {
 });
 
 world.events.itemUseOn.subscribe(async itemUseOn => {
-    const { source: player, item, getBlockLocation } = itemUseOn;
-    const block = player.dimension.getBlock(getBlockLocation());
+    const { source: player, item } = itemUseOn;
+    const block = player.dimension.getBlock(itemUseOn.getBlockLocation());
 
     if (!block instanceof Minecraft.Block || !block?.location) return; 
     


### PR DESCRIPTION
Removed deconstructed method to avoid Native object bound to prototype error.